### PR TITLE
Update apex-clob-load.js

### DIFF
--- a/src/plugin/apex-clob-load.js
+++ b/src/plugin/apex-clob-load.js
@@ -151,7 +151,7 @@ $.widget('ui.apexClobLoad', {
                f01: []
             };
 
-            queryString = uiw._chunkClob(clobData, 30000,  queryString);
+            queryString = uiw._chunkClob(clobData, 15000,  queryString);
 
             $.ajax({
                type: 'POST',


### PR DESCRIPTION
Decrease size of chunk, because on UTF8 base caused Error 500.
This work for me on Oracle Apex 21.1